### PR TITLE
remove mapping types from the ES API calls

### DIFF
--- a/src/main/java/net/opentsdb/search/ElasticSearch.java
+++ b/src/main/java/net/opentsdb/search/ElasticSearch.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.ParseException;
 import org.apache.http.client.config.RequestConfig;
@@ -294,7 +295,7 @@ public final class ElasticSearch extends SearchPlugin {
     final Deferred<SearchQuery> result = new Deferred<SearchQuery>();
 
     final StringBuilder uri = new StringBuilder(host);
-    uri.append("/").append(index).append("/");
+    uri.append("/");
     switch(query.getType()) {
       case TSMETA:
       case TSMETA_SUMMARY:
@@ -325,6 +326,7 @@ public final class ElasticSearch extends SearchPlugin {
     qs.put("query_string", query_string);
 
     final HttpPost post = new HttpPost(uri.toString());
+    post.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
     post.setEntity(new ByteArrayEntity(JSON.serializeToBytes(body)));
 
     http_client.execute(post, new SearchCB(query, result));

--- a/src/main/java/net/opentsdb/search/schemas/annotation/AnnotationSchema.java
+++ b/src/main/java/net/opentsdb/search/schemas/annotation/AnnotationSchema.java
@@ -15,6 +15,7 @@ package net.opentsdb.search.schemas.annotation;
 import java.io.IOException;
 import java.util.concurrent.CancellationException;
 
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
@@ -116,10 +117,8 @@ public abstract class AnnotationSchema {
     
     final StringBuilder uri = new StringBuilder(es.host())
       .append("/")
-      .append(es.index())
-      .append("/")
       .append(doc_type)
-      .append("/")
+      .append("/_doc/")
       .append(note.getStartTime());
     if (!Strings.isNullOrEmpty(note.getTSUID())) {
       uri.append(note.getTSUID());
@@ -129,6 +128,7 @@ public abstract class AnnotationSchema {
     }
     
     final HttpPost post = new HttpPost(uri.toString());
+    post.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
     post.setEntity(new ByteArrayEntity(JSON.serializeToBytes(note)));
     es.httpClient().execute(post, new AsyncCB());
     return result;
@@ -187,10 +187,8 @@ public abstract class AnnotationSchema {
     
     final StringBuilder uri = new StringBuilder(es.host())
       .append("/")
-      .append(es.index())
-      .append("/")
       .append(doc_type)
-      .append("/")
+      .append("/_doc/")
       .append(note.getStartTime());
     if (!Strings.isNullOrEmpty(note.getTSUID())) {
       uri.append(note.getTSUID());

--- a/src/main/java/net/opentsdb/search/schemas/tsmeta/AnalyzedAndMappedTSMetaSchema.java
+++ b/src/main/java/net/opentsdb/search/schemas/tsmeta/AnalyzedAndMappedTSMetaSchema.java
@@ -15,6 +15,7 @@ package net.opentsdb.search.schemas.tsmeta;
 import java.io.IOException;
 import java.util.concurrent.CancellationException;
 
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.concurrent.FutureCallback;
@@ -163,16 +164,15 @@ public class AnalyzedAndMappedTSMetaSchema extends TSMetaSchema {
     
     final StringBuilder uri = new StringBuilder(es.host())
       .append("/")
-      .append(es.index())
-      .append("/")
       .append(doc_type)
-      .append("/")
+      .append("/_doc/")
       .append(meta.getTSUID());
     if (es.asyncReplication()) {
       uri.append("?replication=async");
     }
     
     final HttpPost post = new HttpPost(uri.toString());
+    post.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
     post.setEntity(new ByteArrayEntity(TSMetaAugment.serializeToBytes(meta)));
     es.httpClient().execute(post, new AsyncCB());
     return result;

--- a/src/main/java/net/opentsdb/search/schemas/tsmeta/TSMetaSchema.java
+++ b/src/main/java/net/opentsdb/search/schemas/tsmeta/TSMetaSchema.java
@@ -15,6 +15,7 @@ package net.opentsdb.search.schemas.tsmeta;
 import java.io.IOException;
 import java.util.concurrent.CancellationException;
 
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
@@ -167,16 +168,15 @@ public abstract class TSMetaSchema {
     
     final StringBuilder uri = new StringBuilder(es.host())
       .append("/")
-      .append(es.index())
-      .append("/")
       .append(doc_type)
-      .append("/")
+      .append("/_doc/")
       .append(meta.getTSUID());
     if (es.asyncReplication()) {
       uri.append("?replication=async");
     }
     
     final HttpPost post = new HttpPost(uri.toString());
+    post.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
     post.setEntity(new ByteArrayEntity(JSON.serializeToBytes(meta)));
     es.httpClient().execute(post, new AsyncCB());
     return result;
@@ -235,10 +235,8 @@ public abstract class TSMetaSchema {
     
     final StringBuilder uri = new StringBuilder(es.host())
       .append("/")
-      .append(es.index())
-      .append("/")
       .append(doc_type)
-      .append("/")
+      .append("/_doc/")
       .append(tsuid);
     if (es.asyncReplication()) {
       uri.append("?replication=async");

--- a/src/main/java/net/opentsdb/search/schemas/uidmeta/UIDMetaSchema.java
+++ b/src/main/java/net/opentsdb/search/schemas/uidmeta/UIDMetaSchema.java
@@ -15,6 +15,7 @@ package net.opentsdb.search.schemas.uidmeta;
 import java.io.IOException;
 import java.util.concurrent.CancellationException;
 
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
@@ -119,16 +120,15 @@ public abstract class UIDMetaSchema {
     
     final StringBuilder uri = new StringBuilder(es.host())
       .append("/")
-      .append(es.index())
-      .append("/")
       .append(doc_type)
-      .append("/")
+      .append("/_doc/")
       .append(meta.getUID());
     if (es.asyncReplication()) {
       uri.append("?replication=async");
     }
     
     final HttpPost post = new HttpPost(uri.toString());
+    post.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
     post.setEntity(new ByteArrayEntity(JSON.serializeToBytes(meta)));
     es.httpClient().execute(post, new AsyncCB());
     return result;
@@ -188,10 +188,8 @@ public abstract class UIDMetaSchema {
     
     final StringBuilder uri = new StringBuilder(es.host())
       .append("/")
-      .append(es.index())
-      .append("/")
       .append(doc_type)
-      .append("/")
+      .append("/_doc/")
       .append(meta.getUID());
     if (es.asyncReplication()) {
       uri.append("?replication=async");

--- a/src/test/java/net/opentsdb/search/schemas/annotation/TestDefaultAnnotationSchema.java
+++ b/src/test/java/net/opentsdb/search/schemas/annotation/TestDefaultAnnotationSchema.java
@@ -109,7 +109,7 @@ public class TestDefaultAnnotationSchema {
       deferred.join(1);
       fail("Expected TimeoutException");
     } catch (TimeoutException e) { }
-    assertEquals(HOST + "/" + index + "/" + doc_type + "/1483228800010101", 
+    assertEquals(HOST +  "/" + doc_type + "/_doc/1483228800010101",
         request.getURI().toString());
     
     // good
@@ -120,8 +120,8 @@ public class TestDefaultAnnotationSchema {
     // good with async
     when(es.asyncReplication()).thenReturn(true);
     deferred = schema.index(note);
-    assertEquals(HOST + "/" + index + "/" + doc_type 
-        + "/1483228800010101?replication=async", request.getURI().toString());
+    assertEquals(HOST +  "/" + doc_type
+        + "/_doc/1483228800010101?replication=async", request.getURI().toString());
     final String payload = EntityUtils.toString(((HttpPost) request)
         .getEntity());
     assertTrue(payload.contains("\"description\":\"Unit testing Dragonstone!\""));
@@ -133,8 +133,8 @@ public class TestDefaultAnnotationSchema {
     note.setDescription("Unit testing Dragonstone!");
     note.setStartTime(1483228800);
     deferred = schema.index(note);
-    assertEquals(HOST + "/" + index + "/" + doc_type 
-        + "/1483228800?replication=async", request.getURI().toString());
+    assertEquals(HOST +  "/" + doc_type
+        + "/_doc/1483228800?replication=async", request.getURI().toString());
     
     // bad
     deferred = schema.index(note);
@@ -178,7 +178,7 @@ public class TestDefaultAnnotationSchema {
       deferred.join(1);
       fail("Expected TimeoutException");
     } catch (TimeoutException e) { }
-    assertEquals(HOST + "/" + index + "/" + doc_type + "/1483228800010101", 
+    assertEquals(HOST + "/" + doc_type + "/_doc/1483228800010101",
         request.getURI().toString());
     
     // good
@@ -189,8 +189,8 @@ public class TestDefaultAnnotationSchema {
     // good with async
     when(es.asyncReplication()).thenReturn(true);
     deferred = schema.delete(note);
-    assertEquals(HOST + "/" + index + "/" + doc_type + 
-        "/1483228800010101?replication=async",request.getURI().toString());
+    assertEquals(HOST + "/" + doc_type +
+        "/_doc/1483228800010101?replication=async",request.getURI().toString());
     
     // bad
     deferred = schema.delete(note);

--- a/src/test/java/net/opentsdb/search/schemas/tsmeta/TestAnalyzedAndMappedTSMetaSchema.java
+++ b/src/test/java/net/opentsdb/search/schemas/tsmeta/TestAnalyzedAndMappedTSMetaSchema.java
@@ -115,7 +115,7 @@ public class TestAnalyzedAndMappedTSMetaSchema {
       deferred.join(1);
       fail("Expected TimeoutException");
     } catch (TimeoutException e) { }
-    assertEquals(HOST + "/" + index + "/" + doc_type + "/010101", 
+    assertEquals(HOST + "/" + doc_type + "/_doc/010101",
         request.getURI().toString());
     final String payload = EntityUtils.toString(((HttpPost) request)
         .getEntity());
@@ -137,8 +137,8 @@ public class TestAnalyzedAndMappedTSMetaSchema {
     // good with async
     when(es.asyncReplication()).thenReturn(true);
     deferred = schema.index(meta);
-    assertEquals(HOST + "/" + index + "/" + doc_type 
-        + "/010101?replication=async", request.getURI().toString());
+    assertEquals(HOST + "/" + doc_type
+        + "/_doc/010101?replication=async", request.getURI().toString());
     
     // bad
     deferred = schema.index(meta);
@@ -182,7 +182,7 @@ public class TestAnalyzedAndMappedTSMetaSchema {
       deferred.join(1);
       fail("Expected TimeoutException");
     } catch (TimeoutException e) { }
-    assertEquals(HOST + "/" + index + "/" + doc_type + "/010101", 
+    assertEquals(HOST + "/" + doc_type + "/_doc/010101",
         request.getURI().toString());
     
     // good
@@ -193,8 +193,8 @@ public class TestAnalyzedAndMappedTSMetaSchema {
     // good with async
     when(es.asyncReplication()).thenReturn(true);
     deferred = schema.delete("010101");
-    assertEquals(HOST + "/" + index + "/" + doc_type 
-        + "/010101?replication=async", request.getURI().toString());
+    assertEquals(HOST + "/"  + doc_type
+        + "/_doc/010101?replication=async", request.getURI().toString());
     
     // bad
     deferred = schema.delete("010101");

--- a/src/test/java/net/opentsdb/search/schemas/tsmeta/TestDefaultTSMetaSchema.java
+++ b/src/test/java/net/opentsdb/search/schemas/tsmeta/TestDefaultTSMetaSchema.java
@@ -120,7 +120,7 @@ public class TestDefaultTSMetaSchema {
       deferred.join(1);
       fail("Expected TimeoutException");
     } catch (TimeoutException e) { }
-    assertEquals(HOST + "/" + index + "/" + doc_type + "/010101", 
+    assertEquals(HOST + "/" + doc_type + "/_doc/010101",
         request.getURI().toString());
     
     // good
@@ -131,8 +131,8 @@ public class TestDefaultTSMetaSchema {
     // good with async
     when(es.asyncReplication()).thenReturn(true);
     deferred = schema.index(meta);
-    assertEquals(HOST + "/" + index + "/" + doc_type 
-        + "/010101?replication=async", request.getURI().toString());
+    assertEquals(HOST + "/" + doc_type
+        + "/_doc/010101?replication=async", request.getURI().toString());
     final String payload = EntityUtils.toString(((HttpPost) request)
         .getEntity());
     assertTrue(payload.contains("\"tsuid\":\"010101\""));
@@ -182,7 +182,7 @@ public class TestDefaultTSMetaSchema {
       deferred.join(1);
       fail("Expected TimeoutException");
     } catch (TimeoutException e) { }
-    assertEquals(HOST + "/" + index + "/" + doc_type + "/010101", 
+    assertEquals(HOST + "/" + doc_type + "/_doc/010101",
         request.getURI().toString());
     
     // good
@@ -193,8 +193,8 @@ public class TestDefaultTSMetaSchema {
     // good with async
     when(es.asyncReplication()).thenReturn(true);
     deferred = schema.delete("010101");
-    assertEquals(HOST + "/" + index + "/" + doc_type 
-        + "/010101?replication=async", request.getURI().toString());
+    assertEquals(HOST + "/" + doc_type
+        + "/_doc/010101?replication=async", request.getURI().toString());
     
     // bad
     deferred = schema.delete("010101");

--- a/src/test/java/net/opentsdb/search/schemas/uidmeta/TestDefaultUIDMetaSchema.java
+++ b/src/test/java/net/opentsdb/search/schemas/uidmeta/TestDefaultUIDMetaSchema.java
@@ -106,7 +106,7 @@ public class TestDefaultUIDMetaSchema {
       deferred.join(1);
       fail("Expected TimeoutException");
     } catch (TimeoutException e) { }
-    assertEquals(HOST + "/" + index + "/" + doc_type + "/01", 
+    assertEquals(HOST + "/" + doc_type + "/_doc/01",
         request.getURI().toString());
     
     // good
@@ -117,7 +117,7 @@ public class TestDefaultUIDMetaSchema {
     // good with async
     when(es.asyncReplication()).thenReturn(true);
     deferred = schema.index(meta);
-    assertEquals(HOST + "/" + index + "/" + doc_type + "/01?replication=async", 
+    assertEquals(HOST + "/" + doc_type + "/_doc/01?replication=async",
         request.getURI().toString());
     final String payload = EntityUtils.toString(((HttpPost) request)
         .getEntity());
@@ -166,7 +166,7 @@ public class TestDefaultUIDMetaSchema {
       deferred.join(1);
       fail("Expected TimeoutException");
     } catch (TimeoutException e) { }
-    assertEquals(HOST + "/" + index + "/" + doc_type + "/01", 
+    assertEquals(HOST + "/" + doc_type + "/_doc/01",
         request.getURI().toString());
     
     // good
@@ -177,7 +177,7 @@ public class TestDefaultUIDMetaSchema {
     // good with async
     when(es.asyncReplication()).thenReturn(true);
     deferred = schema.delete(meta);
-    assertEquals(HOST + "/" + index + "/" + doc_type + "/01?replication=async",
+    assertEquals(HOST + "/" + doc_type + "/_doc/01?replication=async",
         request.getURI().toString());
     
     // bad


### PR DESCRIPTION
why
  https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html
  The plugin stores the different type of documents  under the same index and this is not
  possible any more.
  ES API does not accept requests without content type in the header.

what
  * add content type to all of the http requests
  * change the API calls the way that they assume that each type has its own
  index, type name is used as index name
  * update tests accordingly